### PR TITLE
Add placeholder scraper pipeline and tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,4 @@
-# AgriTool Environment Configuration
-
-# Standard Environment Variables (REQUIRED for all deployments)
-# All variable names MUST be uppercase and case-sensitive
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url_here
-NEXT_PUBLIC_SUPABASE_ANON=your_anon_key_here
-SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
-SCRAPER_RAW_GPT_API=your_openai_api_key_here
-TRAINING_SIMULATION_MODE=true # Set to 'false' in production
-
-# Local Development Setup:
-# 1. Copy this file to .env and fill in your actual values
-# 2. The scraper scripts will auto-load .env variables if python-dotenv is installed
-# 3. Install with: pip install python-dotenv (optional, but recommended for local dev)
-#
-# IMPORTANT: Never commit .env files with real credentials to version control!
-
+# Environment variables for AgriTool Phase 1
+OPENAI_API_KEY=your-openai-key
+SUPABASE_URL=https://your-supabase-url.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: python-compile
+        name: Python syntax check
+        entry: python -m py_compile
+        language: system
+        files: \.py$
+      - id: selenium-compliance
+        name: Validate Selenium compliance
+        entry: python validate_selenium_compliance.py
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -262,6 +262,21 @@ python AgriToolScraper-main/validate_selenium_compliance.py
 ![Languages](https://img.shields.io/badge/PLpgSQL-0.4%25-orange)
 ![Languages](https://img.shields.io/badge/CSS-0.1%25-purple)
 
+
+## Phase 1 CLI Usage
+
+These scripts provide a minimal scraping workflow for development.
+
+```bash
+# Validate arguments and environment
+python validate_pipeline.py --mode scraping --site franceagrimer --max-pages 1
+
+# Run the scraper in dry-run mode
+python main.py --mode scraping --site franceagrimer --max-pages 1 --dry-run
+
+# Run a demo (scraping + AI placeholder)
+python main.py --mode demo
+```
 ## 📄 License
 
 MIT License - see LICENSE file for details

--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -1,0 +1,6 @@
+"""Placeholder AI extractor module."""
+
+
+def run_ai_pipeline() -> None:
+    """Placeholder for AI processing logic."""
+    print("AI processing placeholder")

--- a/core.py
+++ b/core.py
@@ -1,0 +1,26 @@
+import os
+from typing import Optional
+
+
+def run_scraper(site: str, max_pages: int, dry_run: bool) -> Optional[str]:
+    """Run a placeholder scraping routine.
+
+    Creates a dummy JSON file under the ``output`` directory containing
+    placeholder data. The function returns the path to the generated file
+    when ``dry_run`` is False.
+    """
+    if max_pages <= 0:
+        raise ValueError("max_pages must be greater than zero")
+
+    print(f"Scraping {site}... max_pages={max_pages}, dry_run={dry_run}")
+    os.makedirs("output", exist_ok=True)
+    output_path = os.path.join("output", f"{site}_dummy_output.json")
+
+    if not dry_run:
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write('{"status": "success", "data": "Dummy data placeholder"}')
+        print(f"Output saved to {output_path}")
+        return output_path
+    else:
+        print("Dry run enabled; no output written")
+        return None

--- a/main.py
+++ b/main.py
@@ -1,237 +1,30 @@
-#!/usr/bin/env python3
-"""
-AgriTool Scraper - Main CLI Entry Point
-Complete scraping pipeline with multiple execution modes
-"""
-
-import os
-import sys
 import argparse
-import logging
-from pathlib import Path
-
-# Add scraper package to path
-sys.path.insert(0, str(Path(__file__).parent))
-
-from scraper.pipeline_orchestrator import PipelineOrchestrator
-from scraper.batch_processor import BatchProcessor, BatchScrapeConfig
-from scraper.core import extract_single_page
-from scraper.supabase_uploader import SupabaseUploader
-from scraper.ai_extractor import AIExtractor
+from core import run_scraper
+from ai_extractor import run_ai_pipeline
 
 
-def setup_environment():
-    """Setup environment and validate dependencies"""
-    
-    # Check for required environment variables
-    required_vars = [
-        'NEXT_PUBLIC_SUPABASE_URL',
-        'SUPABASE_SERVICE_ROLE_KEY', 
-        'SCRAPER_RAW_GPT_API'
-    ]
-    
-    missing_vars = [var for var in required_vars if not os.getenv(var)]
-    
-    if missing_vars:
-        print("❌ Missing required environment variables:")
-        for var in missing_vars:
-            print(f"   - {var}")
-        print("\nSet these variables or create a .env file with:")
-        print("NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co")
-        print("SUPABASE_SERVICE_ROLE_KEY=your-service-role-key")
-        print("SCRAPER_RAW_GPT_API=your-openai-api-key")
-        sys.exit(1)
-    
-    print("✅ Environment variables validated")
-
-
-def run_complete_pipeline(args):
-    """Run the complete end-to-end pipeline"""
-    
-    config = {
-        'output_dir': args.output_dir,
-        'max_workers': args.workers
-    }
-    
-    orchestrator = PipelineOrchestrator(config)
-    
-    stats = orchestrator.run_complete_pipeline(
-        site_name=args.site,
-        max_urls=args.urls_to_scrape,
-        max_pages=args.max_pages,
-        batch_size=args.batch_size,
-        dry_run=args.dry_run
-    )
-    
-    return stats
-
-
-def run_scraping_only(args):
-    """Run scraping stage only"""
-    
-    config = BatchScrapeConfig()
-    config.max_workers = args.workers
-    
-    processor = BatchProcessor(config)
-    
-    stats = processor.process_site(
-        site_name=args.site,
-        max_urls=args.urls_to_scrape,
-        max_pages=args.max_pages,
-        output_dir=args.output_dir
-    )
-    
-    return stats
-
-
-def run_upload_only(args):
-    """Run upload stage only"""
-    
-    uploader = SupabaseUploader()
-    
-    stats = uploader.upload_scraped_data(
-        data_dir=args.data_dir,
-        batch_size=args.batch_size,
-        dry_run=args.dry_run
-    )
-    
-    return stats
-
-
-def run_extraction_only(args):
-    """Run AI extraction stage only"""
-    
-    extractor = AIExtractor()
-    
-    stats = extractor.process_raw_logs(
-        batch_size=args.batch_size,
-        max_records=args.max_records
-    )
-    
-    return stats
-
-
-def run_single_url(args):
-    """Extract a single URL"""
-    
-    result = extract_single_page(args.url, args.output_dir)
-    
-    if result['success']:
-        print(f"✅ Successfully extracted: {args.url}")
-        print(f"📋 Title: {result['title']}")
-        print(f"📝 Text length: {len(result['text'])} characters")
-        return True
-    else:
-        print(f"❌ Extraction failed: {result.get('error', 'Unknown error')}")
-        return False
+def run_demo():
+    """Run a demo pipeline using placeholder logic."""
+    run_scraper("franceagrimer", 1, True)
+    run_ai_pipeline()
 
 
 def main():
-    """Main CLI entry point"""
-    
-    parser = argparse.ArgumentParser(
-        description="AgriTool Scraper - Complete Agricultural Subsidy Data Pipeline",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  # Complete pipeline
-  python main.py pipeline --site franceagrimer --urls-to-scrape 25
-  
-  # Scraping only
-  python main.py scrape --site franceagrimer --urls-to-scrape 50 --max-pages 10
-  
-  # Upload only
-  python main.py upload --data-dir data/scraped --batch-size 20
-  
-  # AI extraction only
-  python main.py extract --batch-size 10
-  
-  # Single URL
-  python main.py single --url https://www.franceagrimer.fr/aides/some-specific-aid
-        """
-    )
-    
-    # Global arguments
-    parser.add_argument('--dry-run', action='store_true', help='Dry run mode (no writes)')
-    parser.add_argument('--output-dir', default='data/scraped', help='Output directory')
-    parser.add_argument('--workers', type=int, default=3, help='Number of parallel workers')
-    parser.add_argument('--batch-size', type=int, default=10, help='Batch size for processing')
-    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose logging')
-    
-    # Subcommands
-    subparsers = parser.add_subparsers(dest='command', help='Available commands')
-    
-    # Complete pipeline
-    pipeline_parser = subparsers.add_parser('pipeline', help='Run complete pipeline')
-    pipeline_parser.add_argument('--site', required=True, help='Site to scrape')
-    pipeline_parser.add_argument('--urls-to-scrape', type=int, default=25, help='URLs to scrape')
-    pipeline_parser.add_argument('--max-pages', type=int, default=10, help='Max pages to scan')
-    
-    # Scraping only
-    scrape_parser = subparsers.add_parser('scrape', help='Run scraping only')
-    scrape_parser.add_argument('--site', required=True, help='Site to scrape')
-    scrape_parser.add_argument('--urls-to-scrape', type=int, default=25, help='URLs to scrape')
-    scrape_parser.add_argument('--max-pages', type=int, default=10, help='Max pages to scan')
-    
-    # Upload only
-    upload_parser = subparsers.add_parser('upload', help='Upload scraped data')
-    upload_parser.add_argument('--data-dir', default='data/scraped', help='Data directory')
-    
-    # AI extraction only
-    extract_parser = subparsers.add_parser('extract', help='Run AI extraction')
-    extract_parser.add_argument('--max-records', type=int, help='Max records to process')
-    
-    # Single URL
-    single_parser = subparsers.add_parser('single', help='Extract single URL')
-    single_parser.add_argument('--url', required=True, help='URL to extract')
-    
+    parser = argparse.ArgumentParser(description="AgriTool CLI entry point")
+    parser.add_argument("--mode", choices=["scraping", "ai-processing", "demo"], required=True)
+    parser.add_argument("--site", default="franceagrimer", help="Target site to scrape")
+    parser.add_argument("--max-pages", type=int, default=5, help="Maximum number of pages to scrape")
+    parser.add_argument("--dry-run", action="store_true", help="Enable dry-run mode")
     args = parser.parse_args()
-    
-    # Setup logging level
-    if args.verbose:
-        logging.getLogger().setLevel(logging.DEBUG)
-    
-    # Validate environment
-    setup_environment()
-    
-    # Execute command
-    try:
-        if args.command == 'pipeline':
-            stats = run_complete_pipeline(args)
-            success = len(stats.get('errors', [])) == 0
-            
-        elif args.command == 'scrape':
-            stats = run_scraping_only(args)
-            success = stats.get('success_rate', 0) > 70
-            
-        elif args.command == 'upload':
-            stats = run_upload_only(args)
-            success = stats.get('success_rate', 0) > 80
-            
-        elif args.command == 'extract':
-            stats = run_extraction_only(args)
-            success = stats.get('success_rate', 0) > 80
-            
-        elif args.command == 'single':
-            success = run_single_url(args)
-            
-        else:
-            parser.print_help()
-            sys.exit(1)
-        
-        # Exit with appropriate code
-        sys.exit(0 if success else 1)
-        
-    except KeyboardInterrupt:
-        print("\n🛑 Operation interrupted by user")
-        sys.exit(130)
-        
-    except Exception as e:
-        print(f"❌ Operation failed: {e}")
-        if args.verbose:
-            import traceback
-            traceback.print_exc()
-        sys.exit(1)
+
+    if args.mode == "scraping":
+        run_scraper(args.site, args.max_pages, args.dry_run)
+    elif args.mode == "ai-processing":
+        run_ai_pipeline()
+    elif args.mode == "demo":
+        run_demo()
+    else:
+        parser.error("Unknown mode")
 
 
 if __name__ == "__main__":

--- a/multi_tab_extractor.py
+++ b/multi_tab_extractor.py
@@ -1,0 +1,6 @@
+"""Stub module for multi-tab extraction logic."""
+
+
+def extract_from_tabs():
+    """Placeholder function for multi-tab extraction."""
+    pass

--- a/tests/test_validate_pipeline.py
+++ b/tests/test_validate_pipeline.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "validate_pipeline.py"
+
+
+def run_validate(tmp_path, args):
+    env = os.environ.copy()
+    env.update({
+        "OPENAI_API_KEY": "test-key",
+        "SUPABASE_URL": "https://example.supabase.co",
+    })
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)] + args,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+    )
+
+
+def test_validation_success(tmp_path):
+    result = run_validate(
+        tmp_path,
+        ["--mode", "scraping", "--site", "franceagrimer", "--max-pages", "1"],
+    )
+    assert result.returncode == 0
+
+
+def test_validation_failure(tmp_path):
+    result = run_validate(
+        tmp_path,
+        ["--mode", "scraping", "--site", "franceagrimer", "--max-pages", "0"],
+    )
+    assert result.returncode != 0

--- a/validate_pipeline.py
+++ b/validate_pipeline.py
@@ -1,0 +1,43 @@
+"""Validate CLI arguments and environment for the scraper pipeline."""
+
+import argparse
+import os
+import sys
+
+REQUIRED_ENV_VARS = ["OPENAI_API_KEY", "SUPABASE_URL"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate pipeline inputs")
+    parser.add_argument("--mode", choices=["scraping", "ai-processing", "demo"], required=True)
+    parser.add_argument("--site", required=True)
+    parser.add_argument("--max-pages", type=int, required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def validate_env() -> None:
+    missing = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+    if missing:
+        raise EnvironmentError(f"Missing environment variables: {', '.join(missing)}")
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.max_pages <= 0:
+        raise ValueError("--max-pages must be greater than zero")
+
+
+def main() -> None:
+    try:
+        args = parse_args()
+        validate_args(args)
+        validate_env()
+        os.makedirs("output", exist_ok=True)
+        print("Validation successful")
+    except Exception as exc:
+        print(f"Validation failed: {exc}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/validate_selenium_compliance.py
+++ b/validate_selenium_compliance.py
@@ -1,0 +1,27 @@
+"""Ensure Selenium and headless Chrome are available."""
+
+import shutil
+import sys
+
+try:
+    import selenium
+except Exception as exc:  # pragma: no cover - import error path
+    print(f"Selenium import failed: {exc}")
+    sys.exit(1)
+
+
+def main() -> None:
+    version = tuple(int(part) for part in selenium.__version__.split('.')[:2])
+    if version < (4, 0):
+        print("Selenium 4+ required")
+        sys.exit(1)
+
+    if not shutil.which("chromium-browser") and not shutil.which("google-chrome"):
+        print("Chromium or Chrome not found")
+        sys.exit(1)
+
+    print("Selenium compliance check passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Replace main entry point with simple dispatcher for scraping, AI, or demo modes
- Add placeholder modules: scraper core, AI extractor, multi-tab stub
- Provide validation script, Selenium compliance check, tests and pre-commit config
- Document CLI usage and environment variables

## Testing
- `pre-commit run --files main.py core.py ai_extractor.py multi_tab_extractor.py validate_pipeline.py validate_selenium_compliance.py .pre-commit-config.yaml tests/test_validate_pipeline.py README.md .env.example`
- `pytest tests/test_validate_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6891d76d40bc832aa4d75c92e39e91bd