### PR TITLE
feat: add AI QA reporting

### DIFF
--- a/ai_extractor.py
+++ b/ai_extractor.py
@@ -8,6 +8,7 @@ original records and optionally written to an output file.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 from pathlib import Path
@@ -35,12 +36,61 @@ def load_prompt(language: str) -> str:
     return (PROMPT_DIR / file_name).read_text(encoding="utf-8")
 
 
+def compute_qa_metrics(results: List[Dict[str, str]]) -> Dict[str, object]:
+    """Compute simple QA statistics from extraction results.
+
+    The function inspects the ``structured_output`` field of each entry and
+    calculates metrics such as missing outputs and field-level blank values.
+    The metrics are lightweight and intended mainly for regression testing and
+    developer insight rather than exhaustive auditing.
+    """
+
+    total = len(results)
+    missing_output = 0
+    field_counts: Dict[str, int] = {}
+    field_blanks: Dict[str, int] = {}
+    lengths: List[int] = []
+
+    for entry in results:
+        output = entry.get("structured_output")
+        if not output:
+            missing_output += 1
+            continue
+
+        lengths.append(len(output))
+        try:
+            data = json.loads(output)
+        except json.JSONDecodeError:
+            # If the model returned non-JSON text we can't do field analysis
+            continue
+
+        for field, value in data.items():
+            field_counts[field] = field_counts.get(field, 0) + 1
+            if value in (None, "", "N/A", "TBD", "Unknown"):
+                field_blanks[field] = field_blanks.get(field, 0) + 1
+
+    avg_length = sum(lengths) / len(lengths) if lengths else 0
+    field_failure_rate = {
+        field: field_blanks.get(field, 0) / count
+        for field, count in field_counts.items()
+    }
+
+    return {
+        "total_records": total,
+        "missing_structured_output": missing_output,
+        "missing_rate": missing_output / total if total else 0,
+        "avg_response_length": avg_length,
+        "field_failure_rate": field_failure_rate,
+    }
+
+
 def run_ai_pipeline(
     batch_path: str = "batches/sample_batch.json",
     model: str = "gpt-4",
     language: str = "fr",
     dry_run: bool = False,
     output_path: str = "output/ai_processed.json",
+    qa_report: bool = False,
 ) -> List[Dict[str, str]]:
     """Process a batch of subsidies with the OpenAI API.
 
@@ -56,6 +106,9 @@ def run_ai_pipeline(
         When ``True`` the results are not written to disk.
     output_path:
         Location where enriched data will be written.
+    qa_report:
+        When ``True`` a ``qa_report.json`` file with basic quality metrics is
+        generated alongside the AI output.
     """
 
     load_dotenv()
@@ -86,16 +139,47 @@ def run_ai_pipeline(
             entry["structured_output"] = None
         results.append(entry)
 
+    output_dir = Path(output_path).parent
     if not dry_run:
-        os.makedirs(Path(output_path).parent, exist_ok=True)
+        os.makedirs(output_dir, exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as fh:
             json.dump(results, fh, indent=2, ensure_ascii=False)
         print(f"[AI] Output saved to {output_path}")
     else:
         print("[AI] Dry-run mode active. No file written.")
 
+    if qa_report:
+        report = compute_qa_metrics(results)
+        os.makedirs(output_dir, exist_ok=True)
+        report_path = output_dir / "qa_report.json"
+        with open(report_path, "w", encoding="utf-8") as fh:
+            json.dump(report, fh, indent=2, ensure_ascii=False)
+        print(f"[AI] QA report saved to {report_path}")
+
     return results
 
 
 if __name__ == "__main__":  # pragma: no cover
-    run_ai_pipeline()
+    parser = argparse.ArgumentParser(description="Run AI extraction pipeline")
+    parser.add_argument("--batch-path", default="batches/sample_batch.json")
+    parser.add_argument("--model", default="gpt-4")
+    parser.add_argument("--language", default="fr")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--output-path", default="output/ai_processed.json", help="Where to save AI output"
+    )
+    parser.add_argument(
+        "--qa-report",
+        action="store_true",
+        help="Generate qa_report.json with quality metrics",
+    )
+    args = parser.parse_args()
+
+    run_ai_pipeline(
+        batch_path=args.batch_path,
+        model=args.model,
+        language=args.language,
+        dry_run=args.dry_run,
+        output_path=args.output_path,
+        qa_report=args.qa_report,
+    )

--- a/main.py
+++ b/main.py
@@ -32,6 +32,11 @@ def main():
     )
     parser.add_argument("--model-name", default="gpt-4", help="Model name for AI processing")
     parser.add_argument("--language", default="fr", help="Language for prompt selection")
+    parser.add_argument(
+        "--qa-report",
+        action="store_true",
+        help="Generate qa_report.json during AI processing",
+    )
     args = parser.parse_args()
 
     if args.mode == "scraping":
@@ -47,6 +52,7 @@ def main():
             model=args.model_name,
             language=args.language,
             dry_run=args.dry_run,
+            qa_report=args.qa_report,
         )
     elif args.mode == "demo":
         run_demo()

--- a/tests/test_ai_qa.py
+++ b/tests/test_ai_qa.py
@@ -1,0 +1,25 @@
+"""Tests for AI extraction QA metrics."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ai_extractor import compute_qa_metrics
+
+
+def test_compute_qa_metrics_basic():
+    entries = [
+        {"structured_output": '{"title": "Grant A", "eligibility": "Farmers"}'},
+        {"structured_output": '{"title": "", "eligibility": ""}'},
+        {"structured_output": None},
+    ]
+
+    report = compute_qa_metrics(entries)
+
+    assert report["total_records"] == 3
+    assert report["missing_structured_output"] == 1
+    # For parsed fields, one of two entries has blank values
+    assert report["field_failure_rate"]["title"] == 0.5
+    assert report["field_failure_rate"]["eligibility"] == 0.5
+    assert report["avg_response_length"] > 0


### PR DESCRIPTION
## Summary
- collect AI extraction quality metrics and save `qa_report.json`
- expose `--qa-report` option in main CLI
- test QA metric computation

## Testing
- `pytest tests/test_ai_qa.py`
- `pytest tests` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'deno'; ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_6891f6365e68832a9903436edd4457e5