### PR TITLE
Add PDF parser and NLP classifier with tests

### DIFF
--- a/document_parser.py
+++ b/document_parser.py
@@ -1,0 +1,31 @@
+"""Utilities for extracting text from project documents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pdfplumber
+
+
+def extract_text_from_pdf(path: str) -> str:
+    """Return text extracted from a PDF file.
+
+    Parameters
+    ----------
+    path:
+        Location of the PDF file to read.
+
+    Returns
+    -------
+    str
+        Concatenated text of all pages in the PDF.
+    """
+    pdf_path = Path(path)
+    if not pdf_path.exists():
+        raise FileNotFoundError(f"PDF file not found: {path}")
+
+    with pdfplumber.open(str(pdf_path)) as pdf:
+        pages = [page.extract_text() or "" for page in pdf.pages]
+
+    # Join pages with newlines and strip leading/trailing whitespace
+    return "\n".join(pages).strip()

--- a/nlp_classifier.py
+++ b/nlp_classifier.py
@@ -1,0 +1,81 @@
+"""Simple NLP based classification helpers for project documents."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List
+
+import openai
+
+
+def _heuristic_classification(text: str) -> Dict[str, object]:
+    """Fallback classification using keyword heuristics."""
+    lowered = text.lower()
+    keywords: List[str] = []
+
+    if "solar" in lowered or "photovolta" in lowered:
+        project_type = "agri-voltaic"
+        keywords.append("solar")
+    elif "irrigation" in lowered:
+        project_type = "irrigation"
+        keywords.append("irrigation")
+    else:
+        project_type = "general"
+
+    region = "Unknown"
+    for candidate in ["occitanie", "bretagne", "andalusia"]:
+        if candidate in lowered:
+            region = candidate.title()
+            keywords.append(candidate)
+            break
+
+    legal_entity = "Unknown"
+    for candidate in ["sas", "sarl", "cooperative"]:
+        if candidate in lowered:
+            legal_entity = candidate.upper()
+            keywords.append(candidate)
+            break
+
+    if "livestock" in lowered and "livestock" not in keywords:
+        keywords.append("livestock")
+    if "greenhouse" in lowered and "greenhouse" not in keywords:
+        keywords.append("greenhouse")
+
+    return {
+        "project_type": project_type,
+        "region": region,
+        "legal_entity": legal_entity,
+        "keywords": keywords,
+    }
+
+
+def classify_project_text(text: str) -> Dict[str, object]:
+    """Classify a project description into structured metadata.
+
+    The function attempts to use OpenAI's ChatCompletion API when an
+    ``OPENAI_API_KEY`` environment variable is available. If the API call fails
+    or no key is configured, a lightweight keyword based heuristic is used
+    instead to provide deterministic behaviour suitable for tests.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        try:  # pragma: no cover - network calls are not tested
+            openai.api_key = api_key
+            prompt = (
+                "Extract project_type, region, legal_entity and keywords from the"
+                " following text. Respond with JSON.\n" + text
+            )
+            response = openai.ChatCompletion.create(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.0,
+            )
+            content = response["choices"][0]["message"]["content"].strip()
+            data = json.loads(content)
+            data.setdefault("keywords", [])
+            return data
+        except Exception:
+            pass
+
+    return _heuristic_classification(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ openai>=1.3.0
 PyPDF2>=3.0.0
 python-docx>=1.1.0
 openpyxl>=3.1.0
+pdfplumber>=0.11.0
 
 # --- Async Support ---
 aiohttp>=3.9.0

--- a/tests/data/sample_project.pdf
+++ b/tests/data/sample_project.pdf
@@ -1,0 +1,71 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 124>>
+stream
+xͱ0FᝧG]j!&:0p_6i/LrZVŷ.O*A:jaNYq7WsPs.yuѕNgqJX8'\0&u}
+%
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+6 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20250805123100)
+>>
+endobj
+7 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000281 00000 n 
+0000000464 00000 n 
+0000000009 00000 n 
+0000000087 00000 n 
+0000000368 00000 n 
+0000000568 00000 n 
+0000000677 00000 n 
+trailer
+<<
+/Size 8
+/Root 7 0 R
+/Info 6 0 R
+>>
+startxref
+780
+%%EOF

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from nlp_classifier import classify_project_text
+
+
+def test_classifier_heuristics():
+    text = (
+        "This project develops solar panels on farmland in Occitanie "
+        "for an SAS company raising livestock."
+    )
+    result = classify_project_text(text)
+    assert result["project_type"] == "agri-voltaic"
+    assert result["region"] == "Occitanie"
+    assert result["legal_entity"] == "SAS"
+    assert "solar" in result["keywords"]
+    assert "livestock" in result["keywords"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,12 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from document_parser import extract_text_from_pdf
+
+
+def test_extract_text_from_pdf():
+    text = extract_text_from_pdf("tests/data/sample_project.pdf")
+    assert "solar farming" in text
+    assert "Occitanie region" in text


### PR DESCRIPTION
## Summary
- add `extract_text_from_pdf` using pdfplumber for PDF ingestion
- implement heuristic `classify_project_text` with optional OpenAI support
- cover PDF parsing and classification with unit tests

## Testing
- `pre-commit run --files document_parser.py nlp_classifier.py tests/test_parser.py tests/test_classifier.py requirements.txt`
- `pytest tests/test_parser.py tests/test_classifier.py`


------
https://chatgpt.com/codex/tasks/task_e_6891f8eb0998832a892510f0eb2f48b2