### PR TITLE
feat: streamline scraper registration

### DIFF
--- a/scrapers/configs/afir.json
+++ b/scrapers/configs/afir.json
@@ -6,5 +6,7 @@
   "detail_selectors": {
     "title": "h1",
     "description": "div#content"
-  }
+  },
+  "currency": "RON",
+  "counties": ["Alba", "Arad", "Argeș", "București", "Cluj"]
 }

--- a/scrapers/country_registry.py
+++ b/scrapers/country_registry.py
@@ -29,6 +29,14 @@ COUNTRY_CONFIGS = {
     "romania": {
         "agencies": ["afir", "apia_procurements", "oportunitati_ue"],
         "languages": ["ro"],
+        "currency": "RON",
+        "counties": [
+            "Alba",
+            "Arad",
+            "Argeș",
+            "București",
+            "Cluj",
+        ],
         "rate_limits": {"requests_per_minute": 60},
         "document_types": ["pdf", "html"],
         "agency_configs": {
@@ -46,11 +54,5 @@ COUNTRY_CONFIGS = {
         "agency_configs": {
             "ec_horizon_detail": "scrapers/configs/ec_horizon_detail.json",
         },
-    },
-    "romania": {
-        "agencies": ["afir"],
-        "languages": ["ro"],
-        "rate_limits": {"requests_per_minute": 30},
-        "document_types": ["pdf", "html"],
     },
 }

--- a/tests/test_country_registry.py
+++ b/tests/test_country_registry.py
@@ -1,0 +1,7 @@
+from scrapers.country_registry import COUNTRY_CONFIGS
+
+
+def test_romania_has_currency_and_counties():
+    ro = COUNTRY_CONFIGS["romania"]
+    assert ro["currency"] == "RON"
+    assert "București" in ro["counties"]


### PR DESCRIPTION
## Summary
- dynamically discover scraper classes so new agencies require no code changes
- add currency and county metadata for Romania and update AFIR config
- cover Romanian registry metadata in tests

## Testing
- `pre-commit run --files scrapers/factory.py scrapers/country_registry.py scrapers/configs/afir.json tests/test_country_registry.py` *(fails: Selenium import failed)*
- `pytest -q` *(fails: cannot import name 'create_client' from 'supabase')*
- `PYTHONPATH=. pytest tests/test_country_registry.py tests/test_scraper_factory.py tests/test_afir_scraper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689210abe190832a916ccb2313736207